### PR TITLE
Fix Duplicate Role key in Lambda creation

### DIFF
--- a/Looping/Macro
+++ b/Looping/Macro
@@ -57,7 +57,6 @@ Resources:
 
       Timeout: "100"
       MemorySize: 128
-      Role: !GetAtt LambdaExecutionRole.Arn
 
   LambdaExecutionRole:
       Type: AWS::IAM::Role


### PR DESCRIPTION
Macro Template has two Role Tags in Lambda Creation.

Thanks for the sample.